### PR TITLE
Fix androidx migration for commandline builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 #/.idea/libraries
 
 # Local configuration file (sdk path, etc)
-gradle.properties
 local.properties
 app/keystore.properties
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@ sudo: false
 
 env:
   matrix:
-    - ANDROID_TARGET=android-28
+    - ANDROID_TARGET=android-29
   global:
     - GRADLE_OPTS="-Xms128m"
 
 android:
   components:
     # needed build tools
-    - build-tools-28.0.3
+    - build-tools-29.0.2
 
     # The SDK version used to compile your project
-    - android-28
+    - android-29
 
     # extra needed components
     - extra-android-m2repository

--- a/app/src/main/res/layout/grid_item_movie.xml
+++ b/app/src/main/res/layout/grid_item_movie.xml
@@ -25,7 +25,7 @@
     tools:layout_width="match_parent"
     tools:layout_height="100dp">
 
-    <androidx.constraintlayout.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/relativeLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -97,5 +97,5 @@
             app:layout_constraintBottom_toBottomOf="@id/meta_info"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
-    </androidx.constraintlayout.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/test/java/org/xbmc/kore/provider/mediaprovider/AbstractTestClass.java
+++ b/app/src/test/java/org/xbmc/kore/provider/mediaprovider/AbstractTestClass.java
@@ -20,6 +20,7 @@ package org.xbmc.kore.provider.mediaprovider;
 import android.content.ContentProviderClient;
 import android.content.ContentResolver;
 import android.content.pm.ProviderInfo;
+import android.os.Build;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -28,12 +29,14 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 import org.xbmc.kore.host.HostInfo;
 import org.xbmc.kore.provider.MediaProvider;
 import org.xbmc.kore.testutils.Database;
 
 @RunWith(AndroidJUnit4.class)
 @Ignore
+@Config(sdk = 28)
 public class AbstractTestClass {
     protected static HostInfo hostInfo;
     private static ContentResolver contentResolver = ApplicationProvider.getApplicationContext().getContentResolver();

--- a/app/src/test/java/org/xbmc/kore/tests/jsonrpc/method/ApplicationTest.java
+++ b/app/src/test/java/org/xbmc/kore/tests/jsonrpc/method/ApplicationTest.java
@@ -16,6 +16,7 @@
 
 package org.xbmc.kore.tests.jsonrpc.method;
 
+import android.os.Build;
 import android.os.Handler;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -41,6 +42,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
+@Config(sdk = 28)
 public class ApplicationTest {
 
     private HostConnection hostConnection;

--- a/app/src/test/java/org/xbmc/kore/tests/jsonrpc/notifications/ApplicationTest.java
+++ b/app/src/test/java/org/xbmc/kore/tests/jsonrpc/notifications/ApplicationTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
+@Config(sdk = 28)
 public class ApplicationTest {
 
     private HostConnection hostConnection;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,16 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Tue Nov 05 20:07:01 CET 2019
+org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx1536M"
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
I needed to change this to be able to build the project in AS 4 and from the commandline.
When running the build on a device Kore still crashes though. So there is some serious testing required I think.